### PR TITLE
Remove dependency on yasm on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,6 @@ CC = /usr/bin/gcc
 CFLAGS = -O3 -Wall -Wextra
 AS = $(CC) $(CFLAGS) -c
 
-# necessary due to shortcomings of LLVM on macOS
-ifeq ($(shell uname -s), Darwin)
-AS = yasm -r cpp -p gas -f macho64
-endif
-
-######################################################
-
 OBJS+= Keccak-simple.o
 OBJS+= randombytes.o
 OBJS+= cpucycles.o

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 # SimpleOT
 The Simplest Oblivious Transfer Protocol by Chou and Orlandi. http://users-cs.au.dk/orlandi/simpleOT/
 Contains a few minor bug fixes and modifications for usability.
-Compilation on macOS requires yasm to be installed, which can be done
-using https://brew.sh: `brew install yasm`

--- a/ge4x_add_p1p1.S
+++ b/ge4x_add_p1p1.S
@@ -110,14 +110,7 @@ sub %r11,%rsp
 # qhasm: input_3 = Gk
 # asm 1: mov  $Gk,>input_3=int64#4
 # asm 2: mov  $Gk,>input_3=%rcx
-#mov  $Gk, %rcx
-
-# replace the above for 64-bit PIE
-# https://stackoverflow.com/questions/52344336/gas-asm-pie-x86-64-access-variable-with-lea-instruction
-
-        call Label
-Label:  pop %rcx
-        add $cvariable(Gk)-Label, %rcx
+mov  cvariable(Gk)@GOTPCREL(%rip), %rcx
 
 # qhasm: r0 aligned= mem256[input_1 + 384]
 # asm 1: vmovupd   384(<input_1=int64#2),>r0=reg256#1


### PR DESCRIPTION
Uses a different assembly construction for PIE, which can be parsed by the assembler from Xcode.