### PR TITLE
Remove exit calls from ot_sender and ot_receiver

### DIFF
--- a/ot_receiver.c
+++ b/ot_receiver.c
@@ -13,19 +13,31 @@ void receiver_maketable(SIMPLEOT_RECEIVER * r)
 
 void receiver_procS(SIMPLEOT_RECEIVER * r)
 {
+	bool success = receiver_procS_check(r);
+	if (!success)
+	{
+		fprintf(stderr, "Error: point decompression failed\n");
+		exit(-1);
+	}
+}
+
+bool receiver_procS_check(SIMPLEOT_RECEIVER * r)
+{
 	int i;
 
 	ge25519 S;
 
 	if (ge25519_unpack_vartime(&S, r->S_pack) != 0)
 	{ 
-		fprintf(stderr, "Error: point decompression failed\n"); exit(-1);
+		return false;
 	}
 
 	for (i = 0; i < 3; i++) ge25519_double(&S, &S); // 8S
 
 	ge25519_pack(r->S_pack, &S); // E_1(S)
 	ge_to_4x(&r->S, &S);
+
+	return true;
 }
 
 void receiver_rsgen(SIMPLEOT_RECEIVER * r, 

--- a/ot_receiver.h
+++ b/ot_receiver.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif
 
 #include <stdio.h>
+#include <stdbool.h>
 
 #include "sc25519.h"
 #include "ge4x.h"
@@ -27,6 +28,7 @@ typedef struct ot_receiver SIMPLEOT_RECEIVER;
 
 void receiver_maketable(SIMPLEOT_RECEIVER *);
 void receiver_procS(SIMPLEOT_RECEIVER *);
+bool receiver_procS_check(SIMPLEOT_RECEIVER *);
 void receiver_rsgen(SIMPLEOT_RECEIVER *, unsigned char *, unsigned char *);
 void receiver_keygen(SIMPLEOT_RECEIVER *, unsigned char (*)[HASHBYTES]);
 

--- a/ot_sender.c
+++ b/ot_sender.c
@@ -33,6 +33,18 @@ void sender_keygen(SIMPLEOT_SENDER * s,
                    unsigned char * Rs_pack, 
                    unsigned char (*keys)[4][HASHBYTES])
 {
+	bool success = sender_keygen_check(s, Rs_pack, keys);
+	if (!success)
+	{
+		fprintf(stderr, "Error: point decompression failed\n");
+		exit(-1);
+	}
+}
+
+bool sender_keygen_check(SIMPLEOT_SENDER * s, 
+                         unsigned char * Rs_pack, 
+                         unsigned char (*keys)[4][HASHBYTES])
+{
 	int i;
 
 	ge4x P0;
@@ -43,7 +55,7 @@ void sender_keygen(SIMPLEOT_SENDER * s,
 
 	if (ge4x_unpack_vartime(&Rs, Rs_pack) != 0)
 	{ 
-		fprintf(stderr, "Error: point decompression failed\n"); exit(-1);
+		return false;
 	}
 
 	for (i = 0; i < 3; i++) ge4x_double(&Rs, &Rs); // 64R^i
@@ -55,5 +67,6 @@ void sender_keygen(SIMPLEOT_SENDER * s,
 
 	ge4x_sub(&P1, &s->yS, &P0); // 64(T-yR^i)
 	ge4x_hash(keys[1][0], s->S_pack, Rs_pack, &P1); // E_2(T - yR^i)
-}
 
+	return true;
+}

--- a/ot_sender.h
+++ b/ot_sender.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif
 
 #include <stdio.h>
+#include <stdbool.h>
 
 #include "ge4x.h"
 #include "sc25519.h"
@@ -22,6 +23,7 @@ typedef struct ot_sender SIMPLEOT_SENDER;
 
 void sender_genS(SIMPLEOT_SENDER *, unsigned char *);
 void sender_keygen(SIMPLEOT_SENDER *, unsigned char *, unsigned char (*)[4][HASHBYTES]);
+bool sender_keygen_check(SIMPLEOT_SENDER *, unsigned char *, unsigned char (*)[4][HASHBYTES]);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Use bool return value to indicate success or failure.

Prevents crashing an application that uses SimpleOT when wrong input is received.