### PR TITLE
Support distros without FHS by taking gcc from environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CC = /usr/bin/gcc
+CC = gcc
 CFLAGS = -O3 -Wall -Wextra
 AS = $(CC) $(CFLAGS) -c
 


### PR DESCRIPTION
We could also write `CC = /usr/bin/env gcc`, but `CC = gcc` apparently works just fine.